### PR TITLE
Update TCP with new Simulator

### DIFF
--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -31,7 +31,7 @@ void SecondaryWindow::on_openSimulator_clicked()
 
     // the commands are prepended by a "start" because "start" will spawn a new process so this program doesnt halt.
     // Runs the simulator:
-    system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisROV.bat && exit");
+    system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisROV6DOF.bat && exit");
     // Runs the python program that sends commands to the simulator. Program replaces a physical controller. This is required when not using a physical controller
     //system("start python C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/tcp_rov_forces.py && exit");
 

--- a/tcprov.h
+++ b/tcprov.h
@@ -35,19 +35,26 @@ public:
     // Data structure to receive from FhSim
     class TCPVessel {
         public:
-            double PosN = 0.0;
-            double PosE = 0.0;
-            double PosD = 0.0;
-            double PosPsi = 0.0;
+            double north = 0.0;
+            double east = 0.0;
+            double down = 0.0;
+            double roll = 0.0;
+            double pitch = 0.0;
+            double yaw = 0.0;
     };
 
     // Data structure to send to FhSim
     class TCPThruster {
         public:
-            double ForceSurge = 500.0;
-            double ForceSway = 0.0;
-            double ForceHeave = 0.0;
-            double ForceYaw = 0.0;
+            double surge= 500.0;
+            double sway = 0.0;
+            double heave = 0.0; // reference depth when AutoDepth == 1
+            double roll = 0.0;  // not implemented in simulator at the moment
+            double pitch = 0.0; // not implemented in simulator at the moment
+            double yaw = 0.0;   // reference heading when AutoHeading = 1
+            // uncomment when new simulator supports it
+            // double autoDepth = 0.0;     // boolean dooble :) 0 for off or 1 for on
+            // double autoHeading = 0.0;   // 0 for off, 1 for on
     };
 
     TCPVessel readData;					// Data to receive from FhSim
@@ -60,7 +67,10 @@ public slots:
     void tcpRead();
     void tcpSend();
     void setValues(double, double, double, double);
-    void resetValues();
+    void setValues(double, double, double, double, double, double);
+    void setValues(double, double, double, double, double, double, double, double);
+    void resetAllValues();
+    void resetValuesButNotFlagValues();
     void startTcpReadTimer();
     void stopTcpReadTimer();
 };


### PR DESCRIPTION
This pr will introduce an updated version of TCP communication to support the new versions of the simulator. 

### support for future version
Since the simulator does not support autoDepth and autoHeading now all the code that supports this are commented out. This was done because we have little time between reciving the simulator and testing with the real ROV

### New Variables and new name changes
We changed the variables to make more sense

    // Data structure to receive from FhSim
    class TCPVessel {
        public:
            double north = 0.0;
            double east = 0.0;
            double down = 0.0;
            double roll = 0.0;
            double pitch = 0.0;
            double yaw = 0.0;
    };

    // Data structure to send to FhSim
    class TCPThruster {
        public:
            double surge= 500.0;
            double sway = 0.0;
            double heave = 0.0; // reference depth when AutoDepth == 1
            double roll = 0.0;  // not implemented in simulator at the moment
            double pitch = 0.0; // not implemented in simulator at the moment
            double yaw = 0.0;   // reference heading when AutoHeading = 1
            // uncomment when new simulator supports it
            // double autoDepth = 0.0;     // boolean dooble :) 0 for off or 1 for on
            // double autoHeading = 0.0;   // 0 for off, 1 for on
    };

### new setValues functions:
// [old but working] this function sets the values that will be sent to the socket
void TcpRov::setValues(double north, double east, double down, double yaw

// [current] this function sets all variables except autoDepth and autoHeading
void TcpRov::setValues(double north, double east, double down, double roll, double pitch, double yaw)

// [future] this function will set all variables
void TcpRov::setValues(double north, double east, double down, double roll, double pitch, double yaw, double autoDepth, double autoHeading)

// this function resets all the nextData variables to zero. This is done such that we don't double send data.
void TcpRov::resetAllValues()

// This function reset all values execpt flags and if a flag is 1 then it will not reset the corresponding value
void TcpRov::resetValuesButNotFlagValues()


