### PR TITLE
Bias

### DIFF
--- a/gamepadserver.cpp
+++ b/gamepadserver.cpp
@@ -81,21 +81,21 @@ namespace GamepadServerLocal {
     }
 
     void updateAnalogs(GamepadState & gps, const XINPUT_GAMEPAD & xStatePad) {
-        gps.m_lTrigger = xStatePad.bLeftTrigger/GamepadServer::maxTriggerValue;
-        gps.m_rTrigger = xStatePad.bRightTrigger/GamepadServer::maxTriggerValue;
-        gps.m_lThumb.xAxis = xStatePad.sThumbLX/GamepadServer::maxJoystickValue;
-        gps.m_lThumb.yAxis = xStatePad.sThumbLY/GamepadServer::maxJoystickValue;
-        gps.m_rThumb.xAxis = xStatePad.sThumbRX/GamepadServer::maxJoystickValue;
-        gps.m_rThumb.yAxis = xStatePad.sThumbRY/GamepadServer::maxJoystickValue;
+        gps.m_lTrigger = (double) xStatePad.bLeftTrigger/GamepadServer::maxTriggerValue;
+        gps.m_rTrigger = (double) xStatePad.bRightTrigger/GamepadServer::maxTriggerValue;
+        gps.m_lThumb.xAxis = (double) xStatePad.sThumbLX/GamepadServer::maxJoystickValue;
+        gps.m_lThumb.yAxis = (double) xStatePad.sThumbLY/GamepadServer::maxJoystickValue;
+        gps.m_rThumb.xAxis = (double) xStatePad.sThumbRX/GamepadServer::maxJoystickValue;
+        gps.m_rThumb.yAxis = (double) xStatePad.sThumbRY/GamepadServer::maxJoystickValue;
 
-        double deadzoneX = 0.15;
-        double deadzoneY = 0.15;
+        double deadzoneX = 0.25;
+        double deadzoneY = 0.25;
 
         // Factoring in deadzone
-        gps.m_lThumb.xAxis = (abs(xStatePad.sThumbLX) < deadzoneX ? 0 : gps.m_lThumb.xAxis);
-        gps.m_lThumb.yAxis = (abs(xStatePad.sThumbLY) < deadzoneY ? 0 : gps.m_lThumb.yAxis);
-        gps.m_rThumb.xAxis = (abs(xStatePad.sThumbRX) < deadzoneX ? 0 : gps.m_rThumb.xAxis);
-        gps.m_rThumb.yAxis = (abs(xStatePad.sThumbRY) < deadzoneY ? 0 : gps.m_rThumb.yAxis);
+        gps.m_lThumb.xAxis = (abs(gps.m_lThumb.xAxis) < deadzoneX ? 0 : gps.m_lThumb.xAxis);
+        gps.m_lThumb.yAxis = (abs(gps.m_lThumb.yAxis) < deadzoneY ? 0 : gps.m_lThumb.yAxis);
+        gps.m_rThumb.xAxis = (abs(gps.m_rThumb.xAxis) < deadzoneX ? 0 : gps.m_rThumb.xAxis);
+        gps.m_rThumb.yAxis = (abs(gps.m_rThumb.yAxis) < deadzoneY ? 0 : gps.m_rThumb.yAxis);
     }
 
 }

--- a/gamepadserver.h
+++ b/gamepadserver.h
@@ -26,6 +26,8 @@ public:
     static const int maxTriggerValue = 255;
 
 
+
+
 signals:
     void stateUpdate(const GamepadState & gps, const int & player);
 

--- a/gamepadstate.h
+++ b/gamepadstate.h
@@ -13,8 +13,8 @@ public:
 
     // Joystick Definition
     struct JoyStick {
-        int16_t xAxis = 0;
-        int16_t yAxis = 0;
+        double xAxis = 0;
+        double yAxis = 0;
         bool pressed=false;
     };
 
@@ -32,8 +32,8 @@ public:
     bool m_lShoulder = false;
 
     // Trigger Buttons
-    uint8_t m_rTrigger = 0;
-    uint8_t m_lTrigger = 0;
+    double m_rTrigger = 0;
+    double m_lTrigger = 0;
 
     // Directional Buttons
     bool m_pad_up = false;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -143,20 +143,36 @@ void MainWindow::catchGamepadState(const GamepadState & gps, const int & playerI
 
     double north = tcpRov->biasSurge + (TcpRov::maxThrusterHorizontal*gps.m_lThumb.yAxis);
     double east = tcpRov->biasSway + (TcpRov::maxThrusterHorizontal*gps.m_lThumb.xAxis);
-
     double down = (gps.m_rTrigger - gps.m_lTrigger);
+
     if (tcpRov->autoDepth) {
-        double adjustment = (down > 0 ? 1 : 0); // 0 or 1
+        qDebug() << "DEPTH: " << tcpRov->referenceDepth;
+        double adjustment = 0;
+        if (down > 0) {
+            adjustment = 1;
+        }
+        else if (down < 0) {
+            adjustment = -1;
+        }
         down = tcpRov->referenceDepth + adjustment*tcpRov->depthAdjustment;
+        tcpRov->referenceDepth += adjustment * tcpRov->depthAdjustment;
     } else {
         down = tcpRov->biasHeave + (TcpRov::maxThrusterVertical*down);
     }
 
     double psi = gps.m_rThumb.xAxis;
 
+
     if (tcpRov->autoHeading) {
-        double adjustment = (psi > 0 ? 1 : 0); // 0 or 1
+        double adjustment = 0;
+        if (psi > 0) {
+            adjustment = 1;
+        }
+        else if (psi < 0) {
+            adjustment = -1;
+        }
         psi = tcpRov->referenceHeading + adjustment*tcpRov->headingAdjustment;
+        tcpRov->referenceHeading += adjustment * tcpRov->headingAdjustment;
     } else {
         psi = (TcpRov::maxThrusterHeading*psi); //TODO: Find right normalisation value
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -110,24 +110,44 @@ void MainWindow::catchGamepadState(const GamepadState & gps, const int & playerI
         lastKeyStateB = 0;
     }
 
+    if (gps.m_pad_up) {
+        tcpRov->biasSurge = std::min(tcpRov->biasSurge+1, TcpRov::maxThrusterHorizontal);
+    }
+    if (gps.m_pad_down) {
+        tcpRov->biasSurge = std::max(tcpRov->biasSurge-1, -TcpRov::maxThrusterHorizontal);;
+    }
+    if (gps.m_pad_right) {
+        tcpRov->biasSway = std::min(tcpRov->biasSway+1, TcpRov::maxThrusterHorizontal);;
+    }
+    if (gps.m_pad_left) {
+        tcpRov->biasSway = std::max(tcpRov->biasSurge-1, -TcpRov::maxThrusterHorizontal);;
+    }
+    if (gps.m_rShoulder) {
+        tcpRov->biasHeave = std::min(tcpRov->biasHeave+1, TcpRov::maxThrusterVertical);;
+    }
+    if (gps.m_lShoulder) {
+        tcpRov->biasHeave = std::max(tcpRov->biasHeave-1, TcpRov::maxThrusterVertical);;
+    }
 
-    double north = (TcpRov::maxThrusterHorizontal*gps.m_lThumb.yAxis);
-    double east = (TcpRov::maxThrusterHorizontal*gps.m_lThumb.xAxis);
+
+
+    double north = tcpRov->biasSurge + (TcpRov::maxThrusterHorizontal*gps.m_lThumb.yAxis);
+    double east = tcpRov->biasSway + (TcpRov::maxThrusterHorizontal*gps.m_lThumb.xAxis);
 
     double down = (gps.m_rTrigger - gps.m_lTrigger);
-    if (tcpRov->autoDepth == 0) {
-        down = (TcpRov::maxThrusterVertical*down);
-    } else {
+    if (tcpRov->autoDepth) {
         double adjustment = (down > 0 ? 1 : 0); // 0 or 1
         down = tcpRov->referenceDepth + adjustment*tcpRov->depthAdjustment;
+    } else {
+        down = tcpRov->biasHeave + (TcpRov::maxThrusterVertical*down);
     }
 
     double psi = gps.m_rThumb.xAxis;
-    if (tcpRov->autoHeading == 0) {
-        psi = (TcpRov::maxThrusterHeading*psi); //TODO: Find right normalisation value
-    } else {
+    if (tcpRov->autoHeading) {
         double adjustment = (psi > 0 ? 1 : 0); // 0 or 1
         psi = tcpRov->referenceHeading + adjustment*tcpRov->headingAdjustment;
+    } else {
+        psi = (TcpRov::maxThrusterHeading*psi); //TODO: Find right normalisation value
     }
 
     tcpRov->setValues(north, east, down, 0, 0, psi, tcpRov->autoDepth, tcpRov->autoHeading);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -82,6 +82,7 @@ void MainWindow::catchGamepadState(const GamepadState & gps, const int & playerI
 
     static bool lastKeyStateA = 0;
     static bool lastKeyStateB = 0;
+    static bool lastKeyStateX = 0;
 
     if (gps.m_pad_a) {
         if (!lastKeyStateA) {
@@ -120,15 +121,24 @@ void MainWindow::catchGamepadState(const GamepadState & gps, const int & playerI
         tcpRov->biasSway = std::min(tcpRov->biasSway+1, TcpRov::maxThrusterHorizontal);;
     }
     if (gps.m_pad_left) {
-        tcpRov->biasSway = std::max(tcpRov->biasSurge-1, -TcpRov::maxThrusterHorizontal);;
+        tcpRov->biasSway = std::max(tcpRov->biasSway-1, -TcpRov::maxThrusterHorizontal);;
     }
     if (gps.m_rShoulder) {
         tcpRov->biasHeave = std::min(tcpRov->biasHeave+1, TcpRov::maxThrusterVertical);;
     }
     if (gps.m_lShoulder) {
-        tcpRov->biasHeave = std::max(tcpRov->biasHeave-1, TcpRov::maxThrusterVertical);;
+        tcpRov->biasHeave = std::max(tcpRov->biasHeave-1, -TcpRov::maxThrusterVertical);;
     }
 
+    if (gps.m_pad_x) {
+        if (!lastKeyStateX) {
+           tcpRov->biasSurge=0;
+           tcpRov->biasSway=0;
+           tcpRov->biasHeave=0;
+         } lastKeyStateX = 1;
+    } else {
+        lastKeyStateX = 0;
+    }
 
 
     double north = tcpRov->biasSurge + (TcpRov::maxThrusterHorizontal*gps.m_lThumb.yAxis);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -153,6 +153,7 @@ void MainWindow::catchGamepadState(const GamepadState & gps, const int & playerI
     }
 
     double psi = gps.m_rThumb.xAxis;
+
     if (tcpRov->autoHeading) {
         double adjustment = (psi > 0 ? 1 : 0); // 0 or 1
         psi = tcpRov->referenceHeading + adjustment*tcpRov->headingAdjustment;

--- a/tcprov.h
+++ b/tcprov.h
@@ -27,9 +27,9 @@ public:
     double autoDepth = 0;
     double autoHeading = 0;
     double referenceDepth = 0;
-    double depthAdjustment = 0.1;
+    double depthAdjustment = 0.01;
     double referenceHeading = 0;
-    double headingAdjustment = 0.1;
+    double headingAdjustment = 0.01;
 
     double biasSurge = 0;
     double biasSway = 0;

--- a/tcprov.h
+++ b/tcprov.h
@@ -31,6 +31,10 @@ public:
     double referenceHeading = 0;
     double headingAdjustment = 0.1;
 
+    double biasSurge = 0;
+    double biasSway = 0;
+    double biasHeave = 0;
+
 
     WSADATA wsaData;                        // initalize Winsock
 


### PR DESCRIPTION
This PR introduces bias. Bias can be reset to 0 by pushing the X button.
It also corrects the fact that the controller could only send 0 or maximum forces. Adjustment of reference depth and reference heading has been properly added.