### PR TITLE
Bias Widget in GUI 

### DIFF
--- a/RovyMcRovFace.pro
+++ b/RovyMcRovFace.pro
@@ -76,7 +76,8 @@ SOURCES += \
     headingwidget.cpp \
     depthwidget.cpp \
     converter.cpp \
-    fontsize.cpp
+    fontsize.cpp \
+    biaswidget.cpp
 
 HEADERS += \
         mainwindow.h \
@@ -91,7 +92,8 @@ HEADERS += \
     depthwidget.h \
     converter.h \
     position.h \
-    fontsize.h
+    fontsize.h \
+    biaswidget.h
 
 FORMS += \
     secondarywindow.ui \

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -1,0 +1,6 @@
+#include "biaswidget.h"
+
+BiasWidget::BiasWidget(QWidget *parent) : QWidget(parent)
+{
+
+}

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -1,6 +1,65 @@
 #include "biaswidget.h"
+#include <QLineF>
+#include <QDebug>
 
-BiasWidget::BiasWidget(QWidget *parent) : QWidget(parent)
+BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWidget(parent)
 {
+    frameWidth = _frameWidth;
+    frameHeight = _frameHeight;
+    antialiased = false;
+    transformed = false;
+}
 
+void BiasWidget::paintEvent(QPaintEvent * ) {
+
+    // make the 7 points we need, each point represent an arrows max position
+    static const QPointF points[7] = {
+        QPointF(frameWidth/2, frameHeight/2), // middle
+        QPointF(frameWidth/2, 0), // middle top
+        QPointF(frameWidth, frameHeight / 3), // right upper
+        QPointF(frameWidth, (frameHeight * 2) / 3), // right lower
+        QPointF(frameWidth/2, frameHeight), // middle bottom
+        QPointF(0, (frameHeight * 2) / 3), // left lower
+        QPointF(0, frameHeight / 3) // left uppder
+    };
+
+    QPainter painter( this );
+
+    painter.setWindow(QRect(0, 0, frameWidth, frameHeight));
+    painter.setViewport(0, 0, frameWidth, frameHeight);
+
+    //pen.setStyle(Qt::DashDotLine);
+    pen.setWidth(3);
+    pen.setBrush(Qt::green);
+    //pen.setCapStyle(Qt::RoundCap);
+    //pen.setJoinStyle(Qt::RoundJoin);
+
+    painter.setPen(pen);
+    painter.setBrush(brush);
+
+    painter.drawRect(QRect(0,0, 40, 40));
+
+    if (antialiased)
+        painter.setRenderHint(QPainter::Antialiasing, true);
+
+    QLineF line = QLineF(points[0], points[1]);
+    line.setLength(100);
+
+    painter.drawLine(line);
+
+
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setPen(palette().dark().color());
+    painter.setBrush(Qt::NoBrush);
+}
+
+QSize BiasWidget::minimumSizeHint() const
+{
+    return QSize(200, 200);
+}
+
+QSize BiasWidget::sizeHint() const
+{
+    qDebug() << "Setting size hint with: " << frameWidth << frameHeight;
+    return QSize(frameWidth, frameHeight);
 }

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -110,6 +110,9 @@ void BiasWidget::paintEvent(QPaintEvent * ) {
     // draw all the background arrows
     drawBackgroundArrows(&painter);
 
+    // draw the arrow letters
+    drawBiasArrowLetters(&painter);
+
     // update length of real bias arrows:
     // testing func: updateBias(-359,200,-50);
 
@@ -155,6 +158,57 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
     if (biasArrowLines->down.length() > 0)
         painter->drawLine(biasArrowLines->down);
 }
+
+void BiasWidget::drawBiasArrowLetters(QPainter *painter) {
+    QString n = "N";
+    QString e = "E";
+    QString d = "D";
+    QString s = "S";
+    QString w = "W";
+    QString u = "U";
+
+    QPointF n_p = north;
+    QPointF e_p = east;
+    QPointF d_p = down;
+    QPointF s_p = south;
+    QPointF w_p = west;
+    QPointF u_p = up;       // hue hue
+
+    // adjust the points to better place the letters
+
+    double spacing = frameWidth / 24;   // random reference point
+
+    n_p.setX( n_p.x() - spacing * 1.4);
+
+    s_p.setX( s_p.x() + spacing * 0.6 );
+    s_p.setY( s_p.y() + spacing * 0.7);
+
+    e_p.setX( e_p.x() + spacing * 0.6 );
+    e_p.setY( e_p.y() + spacing * 0.2 );
+
+    w_p.setX( w_p.x() - spacing * 1.7 );
+    w_p.setY( w_p.y() + spacing * 0.8 );
+
+    u_p.setY( u_p.y() - spacing * 0.4 );
+    u_p.setX( u_p.x() - spacing * 0.45 );
+
+    d_p.setX( d_p.x() - spacing * 0.45 );
+    d_p.setY( d_p.y() + spacing * 1.4 );
+
+    // set the font size
+    QFont font = painter->font();
+    font.setPixelSize(fontSize);
+    painter->setFont(font);
+
+    // Finally draw the text
+    painter->drawText(n_p, n);
+    painter->drawText(s_p, s);
+    painter->drawText(e_p, e);
+    painter->drawText(w_p, w);
+    painter->drawText(u_p, u);
+    painter->drawText(d_p, d);
+}
+
 
 /// Updates the length of the bias arrows
 /// @param double _north => the bias gotten from controller - [-400,400]

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -16,14 +16,20 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     backgroundArrowPen->setWidth(penWidth);
     backgroundArrowPen->setBrush(Qt::darkGray);
 
+    // set fontSize
+    fontSize = frameWidth / 18;
+
+    // We need to pad the points on the frame to allow rendering of text after an arrow
+    double spacing = fontSize * 2;
+
     // Points on the frame that correspond to where the different arrow should point
-    QPointF middle =  QPointF(frameWidth/2, frameHeight/2);        // middle point
-    QPointF up = QPointF(frameWidth/2, 0);                         // top middle
-    QPointF east = QPointF(frameWidth, frameHeight / 3);           // right upper
-    QPointF south = QPointF(frameWidth, (frameHeight * 2) / 3);    // right lower
-    QPointF down = QPointF(frameWidth/2, frameHeight);             // bottom middle
-    QPointF west = QPointF(0, (frameHeight * 2) / 3);              // left lower
-    QPointF north = QPointF(0, frameHeight / 3);                   // left upper
+    middle =  QPointF(frameWidth/2, frameHeight/2);        // middle point
+    up = QPointF(frameWidth/2, spacing);                         // top middle
+    east = QPointF(frameWidth - spacing, frameHeight / 3);           // right upper
+    south = QPointF(frameWidth - spacing, (frameHeight * 2) / 3);    // right lower
+    down = QPointF(frameWidth/2, frameHeight - spacing);             // bottom middle
+    west = QPointF(spacing, (frameHeight * 2) / 3);              // left lower
+    north = QPointF(spacing, frameHeight / 3);                   // left upper
 
     // class used store all the background arrow lines
     backgroundArrowLines = new ArrowLines();
@@ -151,26 +157,26 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
 }
 
 /// Updates the length of the bias arrows
-/// @param double north => the bias gotten from controller - [-400,400]
-/// @param double east => [-400,400]
-/// @param double down => [-200,200]
-void BiasWidget::updateBias(double north, double east, double down) {
-    qDebug() << "Updating bias with " << north << east << down;
-    // update north and south axis:
-    if(north > 0) {
+/// @param double _north => the bias gotten from controller - [-400,400]
+/// @param double _east => [-400,400]
+/// @param double _down => [-200,200]
+void BiasWidget::updateBias(double _north, double _east, double _down) {
+    qDebug() << "Updating bias with " << _north << _east << _down;
+    // update _north and south axis:
+    if(_north > 0) {
         // set south length to 0
         biasArrowLines->south.setLength(0);
         // transform from [0,400] to [0, maxArrowLength]
-        double newLength = FontSize::linearTransform(north, 0, 400, 0, arrowLengthNorth);
+        double newLength = FontSize::linearTransform(_north, 0, 400, 0, arrowLengthNorth);
         // here we have to make a copy of the original line because somehow setLength doesnt work when length is set to zero
         biasArrowLines->north = biasArrowLinesOriginal->north;
         // set the new length
         biasArrowLines->north.setLength(newLength);
         qDebug() << newLength << biasArrowLines->north.length();
-    } else if (north < 0) {
-        // set north length to 0
+    } else if (_north < 0) {
+        // set _north length to 0
         biasArrowLines->north.setLength(0);
-        double newLength = FontSize::linearTransform(abs(north), 0, 400, 0, arrowLengthNorth);
+        double newLength = FontSize::linearTransform(abs(_north), 0, 400, 0, arrowLengthNorth);
         biasArrowLines->south = biasArrowLinesOriginal->south;
         biasArrowLines->south.setLength(newLength);
     } else {
@@ -180,14 +186,14 @@ void BiasWidget::updateBias(double north, double east, double down) {
     }
 
     // east and west axis
-    if (east > 0) {
+    if (_east > 0) {
         biasArrowLines->west.setLength(0);
-        double newLength = FontSize::linearTransform(east, 0, 400, 0, arrowLengthEast);
+        double newLength = FontSize::linearTransform(_east, 0, 400, 0, arrowLengthEast);
         biasArrowLines->east = biasArrowLinesOriginal->east;
         biasArrowLines->east.setLength(newLength);
-    } else if (east < 0) {
+    } else if (_east < 0) {
         biasArrowLines->east.setLength(0);
-        double newLength = FontSize::linearTransform(abs(east), 0, 400, 0, arrowLengthEast);
+        double newLength = FontSize::linearTransform(abs(_east), 0, 400, 0, arrowLengthEast);
         biasArrowLines->west = biasArrowLinesOriginal->west;
         biasArrowLines->west.setLength(newLength);
     } else {
@@ -196,14 +202,14 @@ void BiasWidget::updateBias(double north, double east, double down) {
     }
 
     // up and down axis
-    if (down > 0) {
+    if (_down > 0) {
         biasArrowLines->up.setLength(0);
-        double newLength = FontSize::linearTransform(down, 0, 200, 0, arrowLengthDown);
+        double newLength = FontSize::linearTransform(_down, 0, 200, 0, arrowLengthDown);
         biasArrowLines->down = biasArrowLinesOriginal->down;
         biasArrowLines->down.setLength(newLength);
-    } else if (down < 0) {
+    } else if (_down < 0) {
         biasArrowLines->down.setLength(0);
-        double newLength = FontSize::linearTransform(abs(down), 0, 200, 0, arrowLengthDown);
+        double newLength = FontSize::linearTransform(abs(_down), 0, 200, 0, arrowLengthDown);
         biasArrowLines->up = biasArrowLinesOriginal->up;
         biasArrowLines->up.setLength(newLength);
     } else {

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -12,7 +12,7 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     int penWidth = 6;
 
     backgroundArrowPen = new QPen();
-    backgroundArrowPen->setStyle(Qt::DotLine);
+    backgroundArrowPen->setStyle(Qt::SolidLine);    // tried using DashedLine here instead but it doesnt fill up 100% at the end
     backgroundArrowPen->setWidth(penWidth);
     backgroundArrowPen->setBrush(Qt::darkGray);
 
@@ -65,7 +65,7 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
 
 
     // calculate the length of bias arrows
-    arrowLengthDown = frameHeight / 2;
+    arrowLengthDown = middle.y() - down.y();
     arrowLengthNorth = sqrt(pow(middle.x() - north.x(), 2) + pow(north.y() - middle.y(), 2));
     arrowLengthEast = arrowLengthNorth;
 
@@ -176,7 +176,7 @@ void BiasWidget::drawBiasArrowLetters(QPainter *painter) {
 
     // adjust the points to better place the letters
 
-    double spacing = frameWidth / 24;   // random reference point
+    double spacing = frameWidth / 20;   // random reference point
 
     n_p.setX( n_p.x() - spacing * 1.4);
 
@@ -186,13 +186,13 @@ void BiasWidget::drawBiasArrowLetters(QPainter *painter) {
     e_p.setX( e_p.x() + spacing * 0.6 );
     e_p.setY( e_p.y() + spacing * 0.2 );
 
-    w_p.setX( w_p.x() - spacing * 1.7 );
+    w_p.setX( w_p.x() - spacing * 1.6 );
     w_p.setY( w_p.y() + spacing * 0.8 );
 
+    u_p.setX( u_p.x() - spacing * 0.35 );
     u_p.setY( u_p.y() - spacing * 0.4 );
-    u_p.setX( u_p.x() - spacing * 0.45 );
 
-    d_p.setX( d_p.x() - spacing * 0.45 );
+    d_p.setX( d_p.x() - spacing * 0.35 );
     d_p.setY( d_p.y() + spacing * 1.4 );
 
     // set the font size

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -6,60 +6,74 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
 {
     frameWidth = _frameWidth;
     frameHeight = _frameHeight;
-    antialiased = false;
-    transformed = false;
+
+    // pen used to create background arrows (not the ones created by real bias)
+    backgroundArrowPen = new QPen();
+    backgroundArrowPen->setStyle(Qt::DotLine);
+    backgroundArrowPen->setWidth(6);
+    backgroundArrowPen->setBrush(Qt::darkGray);
+
+
+    // Points on the frame that correspond to where the different arrow should point
+    QPointF middle =  QPointF(frameWidth/2, frameHeight/2);        // middle point
+    QPointF up = QPointF(frameWidth/2, 0);                         // top middle
+    QPointF east = QPointF(frameWidth, frameHeight / 3);           // right upper
+    QPointF south = QPointF(frameWidth, (frameHeight * 2) / 3);    // right lower
+    QPointF down = QPointF(frameWidth/2, frameHeight);             // bottom middle
+    QPointF west = QPointF(0, (frameHeight * 2) / 3);              // left lower
+    QPointF north = QPointF(0, frameHeight / 3);                   // left upper
+
+    // class used store all the background arrow lines
+    backgroundArrowLines = new ArrowLines();
+
+    // Creates the actual lines and store them in the class
+    backgroundArrowLines->up = QLineF(middle, up);
+    backgroundArrowLines->east = QLineF(middle, east);
+    backgroundArrowLines->south = QLineF(middle,south);
+    backgroundArrowLines->down = QLineF(middle, down);
+    backgroundArrowLines->west = QLineF(middle, west);
+    backgroundArrowLines->north = QLineF(middle, north);
 }
 
+/// Draws the entire widget, is called every time component updates
+/// @param QPaintEvent * event Check QPainter spec
 void BiasWidget::paintEvent(QPaintEvent * ) {
-
-    // make the 7 points we need, each point represent an arrows max position
-    static const QPointF points[7] = {
-        QPointF(frameWidth/2, frameHeight/2), // middle
-        QPointF(frameWidth/2, 0), // middle top
-        QPointF(frameWidth, frameHeight / 3), // right upper
-        QPointF(frameWidth, (frameHeight * 2) / 3), // right lower
-        QPointF(frameWidth/2, frameHeight), // middle bottom
-        QPointF(0, (frameHeight * 2) / 3), // left lower
-        QPointF(0, frameHeight / 3) // left uppder
-    };
-
     QPainter painter( this );
 
+    // sets the window and viewport to be the same size as parent
     painter.setWindow(QRect(0, 0, frameWidth, frameHeight));
     painter.setViewport(0, 0, frameWidth, frameHeight);
 
-    //pen.setStyle(Qt::DashDotLine);
-    pen.setWidth(3);
-    pen.setBrush(Qt::green);
-    //pen.setCapStyle(Qt::RoundCap);
-    //pen.setJoinStyle(Qt::RoundJoin);
+    // Activate anti aliasing to improve rendering
+    painter.setRenderHint(QPainter::Antialiasing, true);
 
-    painter.setPen(pen);
-    painter.setBrush(brush);
-
-    painter.drawRect(QRect(0,0, 40, 40));
-
-    if (antialiased)
-        painter.setRenderHint(QPainter::Antialiasing, true);
-
-    QLineF line = QLineF(points[0], points[1]);
-    line.setLength(100);
-
-    painter.drawLine(line);
-
-
-    painter.setRenderHint(QPainter::Antialiasing, false);
-    painter.setPen(palette().dark().color());
-    painter.setBrush(Qt::NoBrush);
+    // draw all the background arrows
+    drawBackgroundArrows(&painter);
 }
 
+/// Draws all the background arrows
+/// @param * painter The QPainter object created in paintEvent
+void BiasWidget::drawBackgroundArrows(QPainter *painter) {
+    painter->setPen(*backgroundArrowPen);
+
+    painter->drawLine(backgroundArrowLines->up);
+    painter->drawLine(backgroundArrowLines->east);
+    painter->drawLine(backgroundArrowLines->south);
+    painter->drawLine(backgroundArrowLines->down);
+    painter->drawLine(backgroundArrowLines->west);
+    painter->drawLine(backgroundArrowLines->north);
+}
+
+/// Sets the minimum size - should never be called tho?
+/// @return QSize - the size of the window
 QSize BiasWidget::minimumSizeHint() const
 {
     return QSize(200, 200);
 }
 
+/// Sets the size of the widget
+/// @return QSize - the wanted size of the widget based on parent witdh and height
 QSize BiasWidget::sizeHint() const
 {
-    qDebug() << "Setting size hint with: " << frameWidth << frameHeight;
     return QSize(frameWidth, frameHeight);
 }

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -9,7 +9,7 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     frameHeight = _frameHeight;
 
     // pen used to create background arrows (not the ones created by real bias)
-    int penWidth = 6;
+    int penWidth = 4;
 
     backgroundArrowPen = new QPen();
     backgroundArrowPen->setStyle(Qt::SolidLine);    // tried using DashedLine here instead but it doesnt fill up 100% at the end
@@ -256,16 +256,17 @@ void BiasWidget::updateBias(double _north, double _east, double _down) {
     }
 
     // up and down axis
+    qDebug() << "Down " << _down;
     if (_down > 0) {
-        biasArrowLines->up.setLength(0);
-        double newLength = FontSize::linearTransform(_down, 0, 200, 0, arrowLengthDown);
-        biasArrowLines->down = biasArrowLinesOriginal->down;
-        biasArrowLines->down.setLength(newLength);
-    } else if (_down < 0) {
         biasArrowLines->down.setLength(0);
         double newLength = FontSize::linearTransform(abs(_down), 0, 200, 0, arrowLengthDown);
         biasArrowLines->up = biasArrowLinesOriginal->up;
         biasArrowLines->up.setLength(newLength);
+    } else if (_down < 0) {
+        biasArrowLines->up.setLength(0);
+        double newLength = FontSize::linearTransform(abs(_down), 0, 200, 0, arrowLengthDown);
+        biasArrowLines->down = biasArrowLinesOriginal->down;
+        biasArrowLines->down.setLength(newLength);
     } else {
         biasArrowLines->down.setLength(0);
         biasArrowLines->up.setLength(0);

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -46,6 +46,18 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     biasArrowLines->west = QLineF(middle, west);
     biasArrowLines->north = QLineF(middle, north);
 
+    // create a copy
+    biasArrowLinesOriginal = new ArrowLines();
+
+    biasArrowLinesOriginal->up = QLineF(middle, up);
+    biasArrowLinesOriginal->east = QLineF(middle, east);
+    biasArrowLinesOriginal->south = QLineF(middle,south);
+    biasArrowLinesOriginal->down = QLineF(middle, down);
+    biasArrowLinesOriginal->west = QLineF(middle, west);
+    biasArrowLinesOriginal->north = QLineF(middle, north);
+
+
+
     // calculate the length of bias arrows
     arrowLengthDown = frameHeight / 2;
     arrowLengthNorth = sqrt(pow(middle.x() - north.x(), 2) + pow(north.y() - middle.y(), 2));
@@ -58,6 +70,8 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     biasArrowLines->down.setLength(0);
     biasArrowLines->west.setLength(0);
     biasArrowLines->north.setLength(0);
+
+
 
     // create the different pens used with real bias arrows
 
@@ -114,8 +128,9 @@ void BiasWidget::drawBackgroundArrows(QPainter *painter) {
 /// @param * painter The QPainter object created in paintEvent
 void BiasWidget::drawBiasArrows(QPainter *painter) {
 
-    // we set new pens on every axis because they should have different colors
+    qDebug() << "drawBiasArrows: " << biasArrowLines->north.length();
 
+    // we set new pens on every axis because they should have different colors
     painter->setPen(*biasArrowPenNorth);
     if (biasArrowLines->north.length() > 0)
         painter->drawLine(biasArrowLines->north);
@@ -140,17 +155,23 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
 /// @param double east => [-400,400]
 /// @param double down => [-200,200]
 void BiasWidget::updateBias(double north, double east, double down) {
-
+    qDebug() << "Updating bias with " << north << east << down;
     // update north and south axis:
     if(north > 0) {
         // set south length to 0
         biasArrowLines->south.setLength(0);
+        // transform from [0,400] to [0, maxArrowLength]
         double newLength = FontSize::linearTransform(north, 0, 400, 0, arrowLengthNorth);
+        // here we have to make a copy of the original line because somehow setLength doesnt work when length is set to zero
+        biasArrowLines->north = biasArrowLinesOriginal->north;
+        // set the new length
         biasArrowLines->north.setLength(newLength);
+        qDebug() << newLength << biasArrowLines->north.length();
     } else if (north < 0) {
         // set north length to 0
         biasArrowLines->north.setLength(0);
         double newLength = FontSize::linearTransform(abs(north), 0, 400, 0, arrowLengthNorth);
+        biasArrowLines->south = biasArrowLinesOriginal->south;
         biasArrowLines->south.setLength(newLength);
     } else {
         // set both to zero
@@ -160,38 +181,38 @@ void BiasWidget::updateBias(double north, double east, double down) {
 
     // east and west axis
     if (east > 0) {
-        // set west length to 0
         biasArrowLines->west.setLength(0);
         double newLength = FontSize::linearTransform(east, 0, 400, 0, arrowLengthEast);
+        biasArrowLines->east = biasArrowLinesOriginal->east;
         biasArrowLines->east.setLength(newLength);
     } else if (east < 0) {
-        // set east length to 0
         biasArrowLines->east.setLength(0);
         double newLength = FontSize::linearTransform(abs(east), 0, 400, 0, arrowLengthEast);
+        biasArrowLines->west = biasArrowLinesOriginal->west;
         biasArrowLines->west.setLength(newLength);
     } else {
-        // set both to zero
         biasArrowLines->east.setLength(0);
         biasArrowLines->west.setLength(0);
     }
 
     // up and down axis
     if (down > 0) {
-        // set up length to 0
         biasArrowLines->up.setLength(0);
         double newLength = FontSize::linearTransform(down, 0, 200, 0, arrowLengthDown);
+        biasArrowLines->down = biasArrowLinesOriginal->down;
         biasArrowLines->down.setLength(newLength);
     } else if (down < 0) {
-        // set down length to 0
         biasArrowLines->down.setLength(0);
         double newLength = FontSize::linearTransform(abs(down), 0, 200, 0, arrowLengthDown);
+        biasArrowLines->up = biasArrowLinesOriginal->up;
         biasArrowLines->up.setLength(newLength);
     } else {
-        // set both to zero
         biasArrowLines->down.setLength(0);
         biasArrowLines->up.setLength(0);
     }
 
+    // update the component, this will call the paintEvent
+    update();
 }
 
 /// Sets the minimum size - should never be called tho?

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -51,6 +51,14 @@ BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWi
     arrowLengthNorth = sqrt(pow(middle.x() - north.x(), 2) + pow(north.y() - middle.y(), 2));
     arrowLengthEast = arrowLengthNorth;
 
+    // set default length to zero
+    biasArrowLines->up.setLength(0);
+    biasArrowLines->east.setLength(0);
+    biasArrowLines->south.setLength(0);
+    biasArrowLines->down.setLength(0);
+    biasArrowLines->west.setLength(0);
+    biasArrowLines->north.setLength(0);
+
     // create the different pens used with real bias arrows
 
     biasArrowPenNorth = new QPen();
@@ -109,16 +117,22 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
     // we set new pens on every axis because they should have different colors
 
     painter->setPen(*biasArrowPenNorth);
-    painter->drawLine(biasArrowLines->north);
-    painter->drawLine(biasArrowLines->south);
+    if (biasArrowLines->north.length() > 0)
+        painter->drawLine(biasArrowLines->north);
+    if (biasArrowLines->south.length() > 0)
+        painter->drawLine(biasArrowLines->south);
 
     painter->setPen(*biasArrowPenEast);
-    painter->drawLine(biasArrowLines->west);
-    painter->drawLine(biasArrowLines->east);
+    if (biasArrowLines->west.length() > 0)
+        painter->drawLine(biasArrowLines->west);
+    if (biasArrowLines->east.length() > 0)
+        painter->drawLine(biasArrowLines->east);
 
     painter->setPen(*biasArrowPenDown);
-    painter->drawLine(biasArrowLines->up);
-    painter->drawLine(biasArrowLines->down);
+    if (biasArrowLines->up.length() > 0)
+        painter->drawLine(biasArrowLines->up);
+    if (biasArrowLines->down.length() > 0)
+        painter->drawLine(biasArrowLines->down);
 }
 
 /// Updates the length of the bias arrows

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -38,13 +38,21 @@ private:
     const double maxArrowLength = 100; // in px
     int frameWidth;
     int frameHeight;
-    // QPen pen;
-    // QBrush brush;
+
+    QPointF middle;
+    QPointF up;
+    QPointF east;
+    QPointF south;
+    QPointF down;
+    QPointF west;
+    QPointF north;
 
     QPen *backgroundArrowPen;
     QPen *biasArrowPenNorth;
     QPen *biasArrowPenEast;
     QPen *biasArrowPenDown;
+
+    double fontSize;
 
     ArrowLines * backgroundArrowLines;
     ArrowLines * biasArrowLines;

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -48,6 +48,7 @@ private:
 
     ArrowLines * backgroundArrowLines;
     ArrowLines * biasArrowLines;
+    ArrowLines * biasArrowLinesOriginal;
 
     double arrowLengthNorth;
     double arrowLengthEast;

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -67,6 +67,7 @@ private:
     //
     void drawBackgroundArrows(QPainter *painter);
     void drawBiasArrows(QPainter *painter);
+    void drawBiasArrowLetters(QPainter *painter);
 
 signals:
 

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -2,16 +2,31 @@
 #define BIASWIDGET_H
 
 #include <QWidget>
+#include <QPainter>
+#include <QBrush>
+#include <QPen>
+#include <QPaintEvent>
 
 class BiasWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit BiasWidget(QWidget *parent = nullptr);
+    explicit BiasWidget(QWidget *parent = nullptr, int _frameWidth = 0, int _frameHeight = 0);
+    QSize minimumSizeHint() const override;
+    QSize sizeHint() const override;
+
+
+protected:
+    void paintEvent(QPaintEvent * event) override;
 
 private:
     const double maxArrowLength = 100; // in px
-
+    int frameWidth;
+    int frameHeight;
+    QPen pen;
+    QBrush brush;
+    bool antialiased;
+    bool transformed;
 
 signals:
 
@@ -20,3 +35,5 @@ public slots:
 };
 
 #endif // BIASWIDGET_H
+
+

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -7,6 +7,17 @@
 #include <QPen>
 #include <QPaintEvent>
 
+/// class used to hold all the lines required to draw one bias widget
+class ArrowLines {
+public:
+    QLineF up;
+    QLineF east;
+    QLineF south;
+    QLineF down;
+    QLineF west;
+    QLineF north;
+};
+
 class BiasWidget : public QWidget
 {
     Q_OBJECT
@@ -20,13 +31,26 @@ protected:
     void paintEvent(QPaintEvent * event) override;
 
 private:
+    //
+    // Variables:
+    //
+
     const double maxArrowLength = 100; // in px
     int frameWidth;
     int frameHeight;
-    QPen pen;
-    QBrush brush;
-    bool antialiased;
-    bool transformed;
+    // QPen pen;
+    // QBrush brush;
+
+    QPen *backgroundArrowPen;
+
+    ArrowLines * backgroundArrowLines;
+
+    //
+    // Functions:
+    //
+    void drawBackgroundArrows(QPainter *painter);
+
+
 
 signals:
 

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -42,19 +42,27 @@ private:
     // QBrush brush;
 
     QPen *backgroundArrowPen;
+    QPen *biasArrowPenNorth;
+    QPen *biasArrowPenEast;
+    QPen *biasArrowPenDown;
 
     ArrowLines * backgroundArrowLines;
+    ArrowLines * biasArrowLines;
+
+    double arrowLengthNorth;
+    double arrowLengthEast;
+    double arrowLengthDown;
 
     //
     // Functions:
     //
     void drawBackgroundArrows(QPainter *painter);
-
-
+    void drawBiasArrows(QPainter *painter);
 
 signals:
 
 public slots:
+    void updateBias(double north, double east, double down);
 
 };
 

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -1,0 +1,22 @@
+#ifndef BIASWIDGET_H
+#define BIASWIDGET_H
+
+#include <QWidget>
+
+class BiasWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit BiasWidget(QWidget *parent = nullptr);
+
+private:
+    const double maxArrowLength = 100; // in px
+
+
+signals:
+
+public slots:
+
+};
+
+#endif // BIASWIDGET_H

--- a/main.cpp
+++ b/main.cpp
@@ -98,6 +98,9 @@ int main(int argc, char *argv[])
     QObject::connect(&w1, qOverload<double>(&MainWindow::updateAutoDepth), dw, &DepthWidget::updateAutoDepth);
     QObject::connect(&w1, qOverload<double>(&MainWindow::updateDepthReference), dw, &DepthWidget::updateDepthReference);
 
+    BiasWidget * bw = w1.biasWidget;
+    QObject::connect(tcpRov, qOverload<double, double, double>(&TcpRov::updateBias), bw, &BiasWidget::updateBias);
+
     //
     // End tcp init
     //

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -59,6 +59,7 @@ void MainWindow::setupUI() {
     depthWidget->setupUI(videoPlayer, & windowWidth, & windowHeight);
 
     // Fancy bias arrow / cordinate system shower;
+    // Create a surrounding QFrame that QPainter can live in
     QFrame * biasContainer = new QFrame( videoPlayer );
     biasContainer->setGeometry(1200,500,500,500);
     biasContainer->setStyleSheet("QFrame { border: 1px solid yellow}");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -10,8 +10,6 @@
 #include <Windows.h>
 #include <QSlider>
 #include <QLabel>
-#include "headingwidget.h"
-#include "depthwidget.h"
 #include <tcprov.h>
 
 using namespace QtAV;
@@ -60,6 +58,11 @@ void MainWindow::setupUI() {
     depthWidget = new DepthWidget ( this );
     depthWidget->setupUI(videoPlayer, & windowWidth, & windowHeight);
 
+    // Fancy bias arrow / cordinate system shower;
+    QFrame * biasContainer = new QFrame( videoPlayer );
+    biasContainer->setGeometry(1200,500,500,500);
+    biasContainer->setStyleSheet("QFrame { border: 1px solid yellow}");
+    biasWidget = new BiasWidget( biasContainer, 500, 500);
 }
 
 MainWindow::~MainWindow()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -62,7 +62,7 @@ void MainWindow::setupUI() {
     // Create a surrounding QFrame that QPainter can live in
     QFrame * biasContainer = new QFrame( videoPlayer );
     biasContainer->setGeometry(1200,500,500,500);
-    biasContainer->setStyleSheet("QFrame { border: 1px solid yellow}");
+    //biasContainer->setStyleSheet("QFrame { border: 1px solid yellow}");
     biasWidget = new BiasWidget( biasContainer, 500, 500);
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -61,9 +61,9 @@ void MainWindow::setupUI() {
     // Fancy bias arrow / cordinate system shower;
     // Create a surrounding QFrame that QPainter can live in
     QFrame * biasContainer = new QFrame( videoPlayer );
-    biasContainer->setGeometry(1200,500,500,500);
+    biasContainer->setGeometry(windowWidth - 400, windowHeight - 400 , 300, 300);
     //biasContainer->setStyleSheet("QFrame { border: 1px solid yellow}");
-    biasWidget = new BiasWidget( biasContainer, 500, 500);
+    biasWidget = new BiasWidget( biasContainer, 300, 300);
 }
 
 MainWindow::~MainWindow()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -8,6 +8,7 @@
 #include <QObject>
 #include "headingwidget.h"
 #include "depthwidget.h"
+#include "biaswidget.h"
 
 class MainWindow : public QMainWindow
 {
@@ -20,6 +21,7 @@ public:
     QWidget * videoPlayer;
     HeadingWidget * headingWidget;
     DepthWidget * depthWidget;
+    BiasWidget * biasWidget;
 
 
     int windowWidth;

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -63,6 +63,7 @@ void TcpRov::tcpRead() {
     emit updateROVValues(readData.north, readData.east, readData.down, readData.roll, readData.pitch, readData.yaw);
     emit updateYaw(readData.yaw);
     emit updateDepth(readData.down);
+    emit updateBias(biasSurge, biasSway, biasHeave);
 
     // send next data
     tcpSend();
@@ -171,8 +172,6 @@ void TcpRov::tcpSend() {
     msg_buf.append((const char*)&nextData.yaw, sizeof(nextData.yaw));
     msg_buf.append((const char*)&nextData.autoDepth, sizeof(nextData.autoDepth));
     msg_buf.append((const char*)&nextData.autoHeading, sizeof(nextData.autoHeading));
-
-    qDebug() << nextData.autoDepth << nextData.autoHeading;
 
     int iResult = send(ConnectSocket, &msg_buf[0], msg_buf.size(), 0);
     qDebug() << "Buffer size: " << msg_buf.size();

--- a/tcprov.h
+++ b/tcprov.h
@@ -84,6 +84,7 @@ signals:
     void updateYaw(double);
     void updateDepth(double);
     void updateFlags(double, double);
+    void updateBias(double, double, double);
 
 public slots:
     void tcpConnect();


### PR DESCRIPTION
This pr will introduce a Bias widget in the lower right of the overlay.

![](https://i.imgur.com/QFTt3nV.gif)

It correctly shows all 3 axis: north & south, east & west, down & up and is as good as scalable.

It uses QPainter under the hood to paint the lines and characters 

Future improvments on this are to create arrows on the ends of each line, but I did not have time to include that